### PR TITLE
fix: Curseforge publishing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,6 +64,10 @@ curseforge {
 		}
 		//addArtifact srcJar
 	}
+
+	options {
+		forgeGradleIntegration = false
+	}
 }
 
 // https://github.com/researchgate/gradle-release


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
📦 Published PR as canary version: <code>1.3.0--canary.8.b4a9a8e</code>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
